### PR TITLE
Make URLs pretty

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,3 +22,4 @@ github_username:  zibraproject
 
 # Build settings
 markdown: kramdown
+permalink: /blog/:title/

--- a/about.md
+++ b/about.md
@@ -15,7 +15,6 @@ Crucially these data will provide a surveillance framework for tracking further 
 
 Data will be subject to open release as it is generated.
 
-<img src="images/mobilelab/And. Laboratoìrio - Vista lateral direita.jpg" />
-<img src="images/mobilelab/lab onibus1.jpg" />
-<img src="images/mobilelab/Riks and Aegypti maps.png" />
-
+<img src="/images/mobilelab/And. Laboratoìrio - Vista lateral direita.jpg" />
+<img src="/images/mobilelab/lab onibus1.jpg" />
+<img src="/images/mobilelab/Riks and Aegypti maps.png" />

--- a/mobile.md
+++ b/mobile.md
@@ -7,16 +7,16 @@ title: "Mobile Lab"
 
 Thanks to the generosity of the Evandro Chagas Institute, we have the use of a containment level three mobile laboratory in a trailer, this is our "lab in a caravan". This will be towed by a 4x4 jeep and start it's journey from Belem to Natal on the 30th of May.
 
-<img src="images/mobilelab/And. Laboratoìrio - Corte lateral direito.jpg" />
-<img src="images/mobilelab/And. Laboratoìrio - Corte lateral esquerdo.jpg" />
-<img src="images/mobilelab/And. Laboratoìrio - Cortes frontal e traseiro.jpg" />
-<img src="images/mobilelab/And. Laboratoìrio - Planta baixa.jpg" />
-<img src="images/mobilelab/And. Laboratoìrio - Vista lateral direita.jpg" />
+<img src="/images/mobilelab/And. Laboratoìrio - Corte lateral direito.jpg" />
+<img src="/images/mobilelab/And. Laboratoìrio - Corte lateral esquerdo.jpg" />
+<img src="/images/mobilelab/And. Laboratoìrio - Cortes frontal e traseiro.jpg" />
+<img src="/images/mobilelab/And. Laboratoìrio - Planta baixa.jpg" />
+<img src="/images/mobilelab/And. Laboratoìrio - Vista lateral direita.jpg" />
 
 The Fundação Oswaldo Cruz (FIOCRUZ) foundation have kindly supplied the use of a bus for this
 trip to help transport the project members between sampling locations.
 
-<img src="images/mobilelab/onibus1.jpg" />
-<img src="images/mobilelab/onibus2.jpg" />
-<img src="images/mobilelab/onibus3.jpg" />
-<img src="images/mobilelab/onibus4.jpg" />
+<img src="/images/mobilelab/onibus1.jpg" />
+<img src="/images/mobilelab/onibus2.jpg" />
+<img src="/images/mobilelab/onibus3.jpg" />
+<img src="/images/mobilelab/onibus4.jpg" />

--- a/people.md
+++ b/people.md
@@ -8,7 +8,7 @@ title: "Who"
 {% for p in site.data.investigators %}
   <div class="biog">
         {% if p.image %}
-	    <img class="biog" src="images/people/thumbs/{{ p.image }}"/>
+	    <img class="biog" src="/images/people/thumbs/{{ p.image }}"/>
         {% endif %}
         <h3 style="padding-bottom: 0px; margin-bottom: 0px;">{{ p.name }}, {{ p.affil }}</h3>
         <p>{{ p.biog }}</p>


### PR DESCRIPTION
The URL `zibraproject.github.io/about/` looks much better than `zibraproject.github.io/about.html`. Making images have absolute paths also makes nesting URLs easier and less error prone.

Also, blog posts are now things like `/blog/zibra-launch-presentation/` rather than `/protocols/2016/05/26/zibra-launch-presentation.html`.
